### PR TITLE
Open Remote ID support over WiFi Beacon using Vendor IE

### DIFF
--- a/Android/app/build.gradle
+++ b/Android/app/build.gradle
@@ -10,13 +10,13 @@ android {
     def versionMinor = 0
     def versionPatch = 0
 
-    compileSdkVersion 29
+    compileSdkVersion 30
     buildToolsVersion = '29.0.3'
 
     defaultConfig {
         applicationId "org.opendroneid.android"
         minSdkVersion 21
-        targetSdkVersion 29
+        targetSdkVersion 30
         versionCode versionMajor * 10000 + versionMinor * 100 + versionPatch
         versionName "${versionMajor}.${versionMinor}.${versionPatch}"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/Android/app/src/main/java/org/opendroneid/android/app/DebugActivity.java
+++ b/Android/app/src/main/java/org/opendroneid/android/app/DebugActivity.java
@@ -39,6 +39,7 @@ import org.opendroneid.android.R;
 import org.opendroneid.android.log.LogWriter;
 import org.opendroneid.android.bluetooth.BluetoothScanner;
 import org.opendroneid.android.bluetooth.WiFiNaNScanner;
+import org.opendroneid.android.bluetooth.WiFiBeaconScanner;
 import org.opendroneid.android.bluetooth.OpenDroneIdDataManager;
 import org.opendroneid.android.data.AircraftObject;
 
@@ -52,6 +53,7 @@ import java.util.Set;
 public class DebugActivity extends AppCompatActivity {
     BluetoothScanner btScanner;
     WiFiNaNScanner wiFiNaNScanner;
+    WiFiBeaconScanner wiFiBeaconScanner;
 
     private AircraftViewModel mModel;
     OpenDroneIdDataManager dataManager;
@@ -73,6 +75,7 @@ public class DebugActivity extends AppCompatActivity {
         mMenuLogItem.setChecked(getLogEnabled());
         checkBluetoothSupport(menu);
         checkNaNSupport(menu);
+        checkWiFiSupport(menu);
         return true;
     }
 
@@ -95,6 +98,12 @@ public class DebugActivity extends AppCompatActivity {
     private void checkNaNSupport(Menu menu) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && getPackageManager().hasSystemFeature(PackageManager.FEATURE_WIFI_AWARE)) {
             menu.findItem(R.id.wifi_nan).setTitle(R.string.nan_supported);
+        }
+    }
+    @TargetApi(Build.VERSION_CODES.R)
+    private void checkWiFiSupport(Menu menu) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            menu.findItem(R.id.wifi_beacon_scan).setTitle(R.string.wifi_beacon_scan_supported);
         }
     }
 
@@ -215,6 +224,12 @@ public class DebugActivity extends AppCompatActivity {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             wiFiNaNScanner = new WiFiNaNScanner(this, dataManager, logger);
             wiFiNaNScanner.startScan();
+        }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            wiFiBeaconScanner = new WiFiBeaconScanner(this, dataManager, logger);
+            if (wiFiBeaconScanner != null) {
+                wiFiBeaconScanner.startScan();
+            }
         }
 
         addDeviceList();

--- a/Android/app/src/main/java/org/opendroneid/android/bluetooth/OpenDroneIdDataManager.java
+++ b/Android/app/src/main/java/org/opendroneid/android/bluetooth/OpenDroneIdDataManager.java
@@ -58,6 +58,12 @@ public class OpenDroneIdDataManager {
         receiveData(timeNano, "NaN ID: " + peerHash, peerHash, 0, message, logMessageEntry);
     }
 
+    void receiveDataWiFi(byte[] data, String mac, long macLong, int rssi, long timeNano, LogMessageEntry logMessageEntry) {
+        OpenDroneIdParser.Message<?> message = OpenDroneIdParser.parseAdvertisingData(data, 1, timeNano, logMessageEntry);
+        if (message == null)
+            return;
+        receiveData(timeNano, mac, macLong, rssi, message, logMessageEntry);
+    }
     @SuppressWarnings("unchecked")
     void receiveData(long timeNano, String macAddress, long macAddressLong, int rssi,
                      OpenDroneIdParser.Message<?> message, LogMessageEntry logMessageEntry) {

--- a/Android/app/src/main/java/org/opendroneid/android/bluetooth/WiFiBeaconScanner.java
+++ b/Android/app/src/main/java/org/opendroneid/android/bluetooth/WiFiBeaconScanner.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright (C) 2021 Skydio Inc
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License. *
+ */
+
+package org.opendroneid.android.bluetooth;
+
+import android.annotation.TargetApi;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.content.pm.PackageManager;
+import android.net.wifi.ScanResult;
+import android.net.wifi.WifiManager;
+import android.os.Build;
+import android.os.CountDownTimer;
+import android.os.Handler;
+import android.os.SystemClock;
+import android.util.Log;
+import android.widget.Toast;
+import androidx.annotation.RequiresApi;
+
+import java.nio.ByteBuffer;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+
+import org.opendroneid.android.log.LogMessageEntry;
+import org.opendroneid.android.log.LogWriter;
+
+public class WiFiBeaconScanner {
+  private static final int OUILen = 3;
+  private static final int DriStartByteOffset = 4;
+  private static final int ScanTimerInterval = 5;
+  private static final int DRIOUI[] = {0x90, 0x3A, 0xE6};
+  private boolean WiFiScanEnabled = true;
+  private final OpenDroneIdDataManager dataManager;
+  private final LogWriter logger;
+  private WifiManager wifiManager;
+  private Handler handler;
+  Context context;
+  int scanSuccess;
+  int scanFailed;
+  String startTime;
+  CountDownTimer countDownTimer;
+  boolean beaconScanDebugEnable;
+
+  private static final String TAG = WiFiBeaconScanner.class.getSimpleName();
+
+  @RequiresApi(api = Build.VERSION_CODES.O)
+  public WiFiBeaconScanner(Context context, OpenDroneIdDataManager dataManager, LogWriter logger) {
+    this.dataManager = dataManager;
+    this.logger = logger;
+
+    this.startTime = getCurrTimeStr();
+
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R ||
+        !context.getPackageManager().hasSystemFeature(PackageManager.FEATURE_WIFI)) {
+      Toast.makeText(context, "WiFi Scanning is not supported", Toast.LENGTH_LONG).show();
+      WiFiScanEnabled = false;
+      return;
+    }
+
+    this.context = context;
+    handler = new Handler();
+    beaconScanDebugEnable = false;
+
+    wifiManager = (WifiManager)context.getSystemService(Context.WIFI_SERVICE);
+    if (!wifiManager.isWifiEnabled()) {
+      Toast.makeText(context, "Turning WiFi ON...", Toast.LENGTH_LONG).show();
+      wifiManager.setWifiEnabled(true);
+    }
+    IntentFilter filter = new IntentFilter(WifiManager.SCAN_RESULTS_AVAILABLE_ACTION);
+    BroadcastReceiver myReceiver = new BroadcastReceiver() {
+      @Override
+      public void onReceive(Context context, Intent intent) {
+        handleScanResults(intent);
+      }
+    };
+    context.registerReceiver(myReceiver, filter);
+
+    startCountDownTimer(context);
+    // Kick off WiFi Scan
+    startScan();
+
+  }
+  @TargetApi(Build.VERSION_CODES.R)
+  void processRemoteIdVendorIE(ScanResult scanResult, ScanResult.InformationElement element) {
+    ByteBuffer buf = element.getBytes();
+    byte[] driOUI = new byte[OUILen];
+    byte[] arr = new byte[buf.remaining()];
+    buf.get(driOUI, 0, OUILen);
+    if ((driOUI[0] & 0xFF) == DRIOUI[0] && (driOUI[1] & 0xFF) == DRIOUI[1] &&
+            (driOUI[2] & 0xFF) == DRIOUI[2]) {
+      buf.position(DriStartByteOffset);
+      buf.get(arr, 0, buf.remaining());
+      LogMessageEntry logMessageEntry = new LogMessageEntry();
+      long timeNano = SystemClock.elapsedRealtimeNanos();
+      dataManager.receiveDataWiFi(arr, scanResult.BSSID, scanResult.BSSID.hashCode(),
+              scanResult.level, timeNano, logMessageEntry);
+    }
+  }
+
+  @TargetApi(Build.VERSION_CODES.R)
+  void handleScanResults(Intent intent){
+    if (wifiManager == null) {
+      Toast.makeText(context, "WiFi beacon scanner attach failed.", Toast.LENGTH_LONG).show();
+      return;
+    }
+    boolean freshScanResult = intent.getBooleanExtra(WifiManager.EXTRA_RESULTS_UPDATED, false);
+    String action = intent.getAction();
+    if ((freshScanResult == true) && WifiManager.SCAN_RESULTS_AVAILABLE_ACTION.equals(action)) {
+      List<ScanResult> wifiList = wifiManager.getScanResults();
+      for (ScanResult scanResult : wifiList) {
+        for (ScanResult.InformationElement element : scanResult.getInformationElements()) {
+          if (element != null && element.getId() == 221) {
+            processRemoteIdVendorIE(scanResult, element);
+          }
+        }
+      }
+      startScan();
+    }
+  }
+
+  @TargetApi(Build.VERSION_CODES.O)
+  public boolean startScan() {
+    if (!WiFiScanEnabled) {
+      return false;
+    }
+    boolean ret = wifiManager.startScan();
+    if (ret) {
+      scanSuccess++;
+    } else {
+      scanFailed++;
+    }
+    Log.d("Wifi", "start_scan:" + ret);
+    printScanStats(ret);
+    return ret;
+  }
+
+  @TargetApi(Build.VERSION_CODES.O)
+  public void stopScan() {
+    if (!WiFiScanEnabled) {
+      return;
+    }
+    if (countDownTimer != null) {
+      countDownTimer.cancel();
+    }
+    Toast.makeText(context, "Stopping WiFi scanning.", Toast.LENGTH_LONG).show();
+  }
+
+  // There are 2 ways to control WiFi scan:
+  // Continuous scan: Calls startSCan() from scan completion callback
+  // Periodic scan: countdown timer triggers startScan after expiry of the timer.
+  // If phone is debug mode and scan throttling is off, scan is triggered from onReceive() callback.
+  // But if scan throttling is turned on on the phone(default setting on the phone), then scan throttling kick in.
+  // In case of throttling, startScan() fails. We need timer thread to periodically kick off scanning.
+  public void startCountDownTimer(Context ctx) {
+    countDownTimer = new CountDownTimer(Long.MAX_VALUE, ScanTimerInterval * 1000) {
+      Context context = ctx;
+
+      // This is called after every ScanTimerInterval sec.
+      public void onTick(long millisUntilFinished) {
+        startScan();
+      }
+      public void onFinish() {
+      }
+    }.start();
+  }
+
+  private String getCurrTimeStr() {
+    SimpleDateFormat sdf = new SimpleDateFormat("yyyyMMdd_HHmmss", Locale.getDefault());
+    String currTime = sdf.format(new Date());
+    return currTime;
+  }
+
+  private void printScanStats(boolean ret){
+    StringBuilder sb = new StringBuilder();
+    sb.append("Started:" + startTime + " ");
+    sb.append( "success:" + scanSuccess + ","
+            + "failed:" + scanFailed);
+    sb.append(" curr-time:" + getCurrTimeStr() + "," + " curr-status:" + ret);
+
+    Log.d("Wifi", sb.toString());
+
+    if (beaconScanDebugEnable) {
+      Toast.makeText(context, sb, Toast.LENGTH_LONG).show();
+    }
+  }
+  public void SetBeaconScanDebug(boolean enable){
+    beaconScanDebugEnable = enable;
+  }
+}

--- a/Android/app/src/main/res/menu/main_menu.xml
+++ b/Android/app/src/main/res/menu/main_menu.xml
@@ -29,6 +29,9 @@
         android:id="@+id/wifi_nan"
         android:title="@string/nan_not_supported" />
     <item
+        android:id="@+id/wifi_beacon_scan"
+        android:title="@string/wifi_beacon_scan_not_supported" />
+    <item
         android:id="@+id/version"
         android:title="@string/app_version" />
 </menu>

--- a/Android/app/src/main/res/values/strings.xml
+++ b/Android/app/src/main/res/values/strings.xml
@@ -34,6 +34,8 @@
     <string name="nan_supported">WiFi NaN supported</string>
 
     <string name="map_not_ready">Map is not ready yet</string>
+    <string name="wifi_beacon_scan_not_supported">WiFi Beacon Scan not supported</string>
+    <string name="wifi_beacon_scan_supported">WiFi Beacon Scan supported</string>
 
     <!--    Permissions    -->
     <string name="permission_rationale_location">Access to the location service is required to demonstrate the \'my location\' feature, which shows your current location on the map.</string>

--- a/Android/gradle/wrapper/gradle-wrapper.properties
+++ b/Android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Sep 03 09:53:30 EEST 2020
+#Tue Feb 09 17:58:03 PST 2021
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip


### PR DESCRIPTION
author Ajay Pathak <ajay.pathak@skydio.com> 1612982156 -0800
committer Ajay Pathak <ajay.pathak@skydio.com> 1615415967 -0800

    Add Open Remote ID support over WiFi Beacon's vendor IE.
    Open Remote ID messages are added as Vendor OUI (90-3A-E6).
    WiFiScannner class triggers WiFi scan and parses beacon.
    If an Open Remote ID message is received, passed to OpenDroneIdDatamanager.

Test: tested with and without wifi throttling mode on pixel-3