### PR TITLE
Update supported-smartphones.md

### DIFF
--- a/supported-smartphones.md
+++ b/supported-smartphones.md
@@ -152,7 +152,7 @@ We plan to continuously update this list and increase the reliability of informa
 
 | Smartphone Model | Chipset | Android version | BT 5 LR Basic Support (Elimination criteria) | BT 5 LR Receiver Support | Wi-Fi Beacon | Wi-Fi NAN  | Proof | Note |
 | ---------------- | ------- | --------------- | -------------------------------------------- | ------------------------ | ------------ | ---------- | ----- | ---- |
-| Asus Zenfone 6                                   | Snapdragon 855    | 11 | ✅ 1/2021  | ✅ 7/2021  | ✅ 7/2021  | ✅ 1/2021  | [Link](receiver_proofs/Asus_Zenfone6) | |
+| Asus Zenfone 6                                   | Snapdragon 855    | 11 | ✅ 1/2021  | ✅ 7/2021  | ✅ 7/2021  | ✅ 1/2021  | [Link](receiver_proofs/Asus_Zenfone6) | Does not receive Long Range continuously (gaps of up to 5 sec) |
 | Google Pixel 4/4XL                               | Snapdragon 855    | 10 |            |            |            | ✅ 1/2020  |      | |
 | Google Pixel 3/3XL                               | Snapdragon 845    |  9 |            |            |            | ✅ 1/2020  |      | |
 | Google Pixel 3A                                  | Snapdragon 670    | 10 | ❌ 1/2020  | ❌ 1/2020  |            | ✅ 1/2020  |      | |


### PR DESCRIPTION
Asus Zenfone 6: BT5 LR is not received continuously. I observed gaps of up to 5 seconds.