### PR TITLE
Supported Smartphones: add Pixel 6

### DIFF
--- a/supported-smartphones.md
+++ b/supported-smartphones.md
@@ -161,6 +161,7 @@ We plan to continuously update this list and increase the reliability of informa
 | Smartphone Model | Chipset | Android version | BT 5 LR Basic Support (Elimination criteria) | BT 5 LR Receiver Support | Wi-Fi Beacon | Wi-Fi NAN  | Proof | Note |
 | ---------------- | ------- | --------------- | -------------------------------------------- | ------------------------ | ------------ | ---------- | ----- | ---- |
 | Asus Zenfone 6                                   | Snapdragon 855    | 11 | ✅ 1/2021  | ✅ 7/2021  | ✅ 7/2021  | ✅ 1/2021  | [Link](receiver_proofs/Asus_Zenfone6) | Does not receive Long Range continuously (gaps of up to 5 sec) |
+| Google Pixel 6                                   | Google Tensor     | 12 | ✅ 11/2021 | ❌ 11/2021 | ✅ 11/2021 | ✅ 11/2021 |      | Long range support is claimed but the signals are never received |
 | Google Pixel 4/4XL                               | Snapdragon 855    | 10 |            |           |     ➕     | ✅ 1/2020  |      | |
 | Google Pixel 3/3XL                               | Snapdragon 845    |  9 |            |           |     ➕     | ✅ 1/2020  |      | |
 | Google Pixel 3A                                  | Snapdragon 670    | 10 | ❌ 1/2020  | ❌ 1/2020  |     ➕     | ✅ 1/2020  |      | |


### PR DESCRIPTION
* nRF Connect claims support for Coded PHY and Extended Advertisements
* devices that only advertise via BT5 only are not seen, though
* BT4 advertisements are received alright
* WiFi Beacon has been verified with a Parrot Anafi
* WiFi Aware support is shown in AIDA64 (but I have no sender device to verify it)
* all of this was tested with ODID 3.0 (targeting API 30 / Android 11)