### PR TITLE
Supported Smartphones: add Samsung S21

### DIFF
--- a/supported-smartphones.md
+++ b/supported-smartphones.md
@@ -208,6 +208,7 @@ We plan to continuously update this list and increase the reliability of informa
 | Samsung Galaxy Note 9 (USA, China, Japan)        | Snapdragon 845    |    |            |            |     ➕      |            |      | |
 | Samsung Galaxy Note 8 (Global)                   | Exynos 8895       |  9 |            |            | ✅ 1/2020  |            |      | |
 | Samsung Galaxy Note 8 (USA, China, Japan)        | Snapdragon 835    |    |            |            |     ➕      |            |      | |
+| Samsung S21, S21+, S21 Ultra                     | Exynos 2100       | 11 | ✅ 11/2021 | ✅ 11/2021 | ✅ 11/2020 | ✅ 11/2020 |      | Receives Long Range continuously |
 | Samsung S20, S20+, S20 ultra (Global)            | Exynos 990        | 10 | ✅ 1/2021  | ✅ 1/2021  | ✅ 1/2020  | ✅ 1/2020  | [Link](receiver_proofs/Samsung_Galaxy_S20_Exynos) | |
 | Samsung S20, S20+, S20 ultra (USA, China, Japan) | Snapdragon 865    | 10 | ✅ 2/2021  | ✅ 2/2021  |      ➕     | ✅ 2/2021  |      | Receives Long Range continuously |
 | Samsung Galaxy S10, S10e, S10+, S10 5G           | Exynos 9820       | 10 | ✅ 1/2021  | ✅ 1/2021  | ✅ 1/2020  | ✅ 1/2020  | [Link](receiver_proofs/Samsung_Galaxy_S10_Exynos) | Receives Long Range continuously |


### PR DESCRIPTION
* everything supported (no surprise, since the S20 already did that)
* nRF Connect shows support for Coded PHY and Extended Advertisements
* BT 5 has been verified with a DroneTag Mini (and other devices), and the reception is continuous without gaps
* WiFi Beacon has been verified with a Parrot Anafi
* WiFi Aware support is shown in AIDA64 (but I have no sender device to verify it)
* all of this was tested with an S21+ (but I assume the S21 and S21 Ultra variants behave the same way)
* using ODID 3.0 (and another receiver app)