### PR TITLE
Fix wrong order of operations

### DIFF
--- a/Android/app/src/main/java/org/opendroneid/android/data/LocationData.java
+++ b/Android/app/src/main/java/org/opendroneid/android/data/LocationData.java
@@ -300,7 +300,7 @@ public class LocationData extends MessageData {
     }
 
     public double getLocationTimestamp() { return locationTimestamp; }
-    private double getTimeStampMinutes() { return (float) ((int) (locationTimestamp / 10)) / 60; }
+    private double getTimeStampMinutes() { return (float) (((int) (locationTimestamp / 10)) / 60); }
     private double getTimeStampSeconds() { return (locationTimestamp/10) % 60; }
     public String getLocationTimestampAsString() {
         if (locationTimestamp == 0xFFFF)


### PR DESCRIPTION
Without the change, the value is casted to float first, which causes the minutes to be wrongly rounded up after the second half of the minute.