### PR TITLE
add a list of transmitter devices

### DIFF
--- a/transmitter-devices.md
+++ b/transmitter-devices.md
@@ -1,0 +1,24 @@
+# Transmitter Devices
+
+This page provides a list of transmitter devices that are capable of broadcasting Direct Remote ID signals according to ASD-STAN prEN4709-02 (EU version) and ASTM F3411-19 (US version).
+
+The list is divided into three sections: drones, add-on devices and other implementations.
+
+## Drones / UAV
+
+| Device        | BT 4 | BT 5 | Wi-Fi Beacon | Wi-Fi NAN | Link                                                |
+| ------------- | ---- | ---- | ------------ | --------- | --------------------------------------------------- |
+| Parrot Anafi  | ❌   | ❌   | ✅            | ❌        | https://www.parrot.com/en/drones/anafi              |
+
+## Add-on Devices
+
+| Device        | BT 4 | BT 5 | Wi-Fi Beacon | Wi-Fi NAN | Link                                                |
+| ------------- | ---- | ---- | ------------ | --------- | --------------------------------------------------- |
+| Aerobits idME | ✅   | ✅   | ❌            | ❌        | https://www.aerobits.pl/product/idme/               |
+| DroneTag Mini | ✅   | ✅   | ❌            | ❌        | https://dronetag.cz/en/products/mini/               |
+| INVOLI LEMAN  |      |      |              |           | https://www.involi.com/products/leman-drone-tracker |
+
+## Other Transmitter Implementations
+
+* Linux: https://github.com/opendroneid/transmitter-linux
+* Arduino / ESP32: https://github.com/sxjack/uav_electronic_ids

--- a/transmitter-devices.md
+++ b/transmitter-devices.md
@@ -16,7 +16,7 @@ The list is divided into three sections: drones, add-on devices and other implem
 | ------------- | ---- | ---- | ------------ | --------- | --------------------------------------------------- |
 | Aerobits idME | ✅   | ✅   | ❌            | ❌        | https://www.aerobits.pl/product/idme/               |
 | DroneTag Mini | ✅   | ✅   | ❌            | ❌        | https://dronetag.cz/en/products/mini/               |
-| INVOLI LEMAN  |      |      |              |           | https://www.involi.com/products/leman-drone-tracker |
+| INVOLI LEMAN  | ❌   | ❌   |              | ✅         | https://www.involi.com/products/leman-drone-tracker |
 
 ## Other Transmitter Implementations
 

--- a/transmitter-devices.md
+++ b/transmitter-devices.md
@@ -6,9 +6,9 @@ The list is divided into three sections: drones, add-on devices and other implem
 
 ## Drones / UAV
 
-| Device        | BT 4 | BT 5 | Wi-Fi Beacon | Wi-Fi NAN | Link                                                |
-| ------------- | ---- | ---- | ------------ | --------- | --------------------------------------------------- |
-| Parrot Anafi  | ❌   | ❌   | ✅            | ❌        | https://www.parrot.com/en/drones/anafi              |
+| Device        | BT 4 | BT 5 | Wi-Fi Beacon | Wi-Fi NAN | Link                                   | Notes                       |
+| ------------- | ---- | ---- | ------------ | --------- | -------------------------------------- | --------------------------- |
+| Parrot Anafi  | ❌   | ❌   | ✅            | ❌        | https://www.parrot.com/en/drones/anafi | FW version >= 1.8.0 required |
 
 ## Add-on Devices
 


### PR DESCRIPTION
This PR makes a start with setting up a list of transmitter devices, as proposed in #52.

The INVOLI device is included, but it's not clear which transport types it supports (the website only mentions "Wi-Fi", but does not say whether NAN or Beacon is meant). The other entries I have verified myself.