### PR TITLE
Add Japanese to multi-language

### DIFF
--- a/Android/app/src/main/res/layout/aircraft_details.xml
+++ b/Android/app/src/main/res/layout/aircraft_details.xml
@@ -27,21 +27,21 @@
                 style="@style/Details.Heading"
                 android:layout_width="99dp"
                 android:layout_height="wrap_content"
-                android:text="Connection" />
+                android:text="@string/Connection" />
 
             <TextView
                 android:id="@+id/msgVersion"
                 android:layout_width="50dp"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_horizontal"
-                android:text="-" />
+                android:text="@string/unknown" />
 
             <TextView
                 android:id="@+id/receiveTime"
                 android:layout_width="170dp"
                 android:layout_height="wrap_content"
                 android:layout_gravity="end"
-                android:text="–" />
+                android:text="@string/unknown" />
 
             <TableLayout
                 android:layout_width="match_parent"
@@ -57,13 +57,13 @@
 
                     <TextView
                         style="@style/Details.Label"
-                        android:text="RSSI" />
+                        android:text="@string/RSSI" />
 
                     <TextView
                         android:id="@+id/conRssi"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="–" />
+                        android:text="@string/unknown" />
 
                     <TextView
                         style="@style/Details.Label"
@@ -73,7 +73,7 @@
                         android:id="@+id/conMac"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="–" />
+                        android:text="@string/unknown" />
                 </TableRow>
 
                 <TableRow
@@ -82,23 +82,23 @@
 
                     <TextView
                         style="@style/Details.Label"
-                        android:text="Started" />
+                        android:text="@string/Started" />
 
                     <TextView
                         android:id="@+id/conStarted"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="–" />
+                        android:text="@string/unknown" />
 
                     <TextView
                         style="@style/Details.Label"
-                        android:text="Last seen" />
+                        android:text="@string/Last_seen" />
 
                     <TextView
                         android:id="@+id/conLastUpdate"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="–" />
+                        android:text="@string/unknown" />
                 </TableRow>
 
                 <TableRow
@@ -107,23 +107,23 @@
 
                     <TextView
                         style="@style/Details.Label"
-                        android:text="Msg &#8710;" />
+                        android:text="@string/Msg_8710" />
 
                     <TextView
                         android:id="@+id/conMsgDelta"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="–" />
+                        android:text="@string/unknown" />
 
                     <TextView
                         style="@style/Details.Label"
-                        android:text="Distance" />
+                        android:text="@string/Distance" />
 
                     <TextView
                         android:id="@+id/distance"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="–" />
+                        android:text="@string/unknown" />
                 </TableRow>
             </TableLayout>
         </androidx.cardview.widget.CardView>
@@ -139,14 +139,14 @@
                 style="@style/Details.Heading"
                 android:layout_width="99dp"
                 android:layout_height="wrap_content"
-                android:text="Basic ID 1" />
+                android:text="@string/Basic_ID_1" />
 
             <TextView
                 android:id="@+id/infoLastUpdate1"
                 android:layout_width="78dp"
                 android:layout_height="wrap_content"
                 android:layout_gravity="end"
-                android:text="–"
+                android:text="@string/unknown"
                 android:textAlignment="viewEnd" />
 
             <TableLayout
@@ -163,23 +163,23 @@
 
                     <TextView
                         style="@style/Details.Label"
-                        android:text="Type" />
+                        android:text="@string/Type" />
 
                     <TextView
                         android:id="@+id/infoType1"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="–" />
+                        android:text="@string/unknown" />
 
                     <TextView
                         style="@style/Details.Label"
-                        android:text="ID Type" />
+                        android:text="@string/ID_Type" />
 
                     <TextView
                         android:id="@+id/infoIdType1"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="–" />
+                        android:text="@string/unknown" />
                 </TableRow>
 
                 <TableRow
@@ -188,13 +188,13 @@
 
                     <TextView
                         style="@style/Details.Label"
-                        android:text="UAS ID" />
+                        android:text="@string/UAS_ID" />
 
                     <TextView
                         android:id="@+id/infoUasId1"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="–"
+                        android:text="@string/unknown"
                         android:layout_span="3" />
                 </TableRow>
 
@@ -212,14 +212,14 @@
                 style="@style/Details.Heading"
                 android:layout_width="99dp"
                 android:layout_height="wrap_content"
-                android:text="Basic ID 2" />
+                android:text="@string/Basic_ID_2" />
 
             <TextView
                 android:id="@+id/infoLastUpdate2"
                 android:layout_width="78dp"
                 android:layout_height="wrap_content"
                 android:layout_gravity="end"
-                android:text="–"
+                android:text="@string/unknown"
                 android:textAlignment="viewEnd" />
 
             <TableLayout
@@ -236,23 +236,23 @@
 
                     <TextView
                         style="@style/Details.Label"
-                        android:text="Type" />
+                        android:text="@string/Type" />
 
                     <TextView
                         android:id="@+id/infoType2"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="–" />
+                        android:text="@string/unknown" />
 
                     <TextView
                         style="@style/Details.Label"
-                        android:text="ID Type" />
+                        android:text="@string/ID_Type" />
 
                     <TextView
                         android:id="@+id/infoIdType2"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="–" />
+                        android:text="@string/unknown" />
                 </TableRow>
 
                 <TableRow
@@ -261,13 +261,13 @@
 
                     <TextView
                         style="@style/Details.Label"
-                        android:text="UAS ID" />
+                        android:text="@string/UAS_ID" />
 
                     <TextView
                         android:id="@+id/infoUasId2"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="–"
+                        android:text="@string/unknown"
                         android:layout_span="3" />
                 </TableRow>
 
@@ -283,14 +283,14 @@
 
             <TextView
                 style="@style/Details.Heading"
-                android:text="Location" />
+                android:text="@string/Location" />
 
             <TextView
                 android:id="@+id/posLastUpdate"
                 android:layout_width="78dp"
                 android:layout_height="wrap_content"
                 android:layout_gravity="end"
-                android:text="–"
+                android:text="@string/unknown"
                 android:textAlignment="viewEnd" />
 
             <TableLayout
@@ -307,23 +307,23 @@
 
                     <TextView
                         style="@style/Details.Label"
-                        android:text="Latitude" />
+                        android:text="@string/Latitude" />
 
                     <TextView
                         android:id="@+id/lat"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="–" />
+                        android:text="@string/unknown" />
 
                     <TextView
                         style="@style/Details.Label"
-                        android:text="Longitude" />
+                        android:text="@string/Longitude" />
 
                     <TextView
                         android:id="@+id/lon"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="–" />
+                        android:text="@string/unknown" />
                 </TableRow>
 
                 <TableRow
@@ -332,23 +332,23 @@
 
                     <TextView
                         style="@style/Details.Label"
-                        android:text="Altitude Press." />
+                        android:text="@string/Altitude_Press" />
 
                     <TextView
                         android:id="@+id/altitudePressure"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="–" />
+                        android:text="@string/unknown" />
 
                     <TextView
                         style="@style/Details.Label"
-                        android:text="Alt. Geod." />
+                        android:text="@string/Alt_Geod" />
 
                     <TextView
                         android:id="@+id/altitudeGeodetic"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="–" />
+                        android:text="@string/unknown" />
                 </TableRow>
 
                 <TableRow
@@ -357,23 +357,23 @@
 
                     <TextView
                         style="@style/Details.Label"
-                        android:text="Direction" />
+                        android:text="@string/Direction" />
 
                     <TextView
                         android:id="@+id/direction"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="–" />
+                        android:text="@string/unknown" />
 
                     <TextView
                         style="@style/Details.Label"
-                        android:text="Status" />
+                        android:text="@string/Status" />
 
                     <TextView
                         android:id="@+id/status"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="–" />
+                        android:text="@string/unknown" />
                 </TableRow>
 
                 <TableRow
@@ -382,23 +382,23 @@
 
                     <TextView
                         style="@style/Details.Label"
-                        android:text="Hori. Speed" />
+                        android:text="@string/Hori_Speed" />
 
                     <TextView
                         android:id="@+id/horiSpeed"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="–" />
+                        android:text="@string/unknown" />
 
                     <TextView
                         style="@style/Details.Label"
-                        android:text="Vert. Speed" />
+                        android:text="@string/Vert_Speed" />
 
                     <TextView
                         android:id="@+id/vertSpeed"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="–" />
+                        android:text="@string/unknown" />
                 </TableRow>
 
                 <TableRow
@@ -407,23 +407,23 @@
 
                     <TextView
                         style="@style/Details.Label"
-                        android:text="Height" />
+                        android:text="@string/Height" />
 
                     <TextView
                         android:id="@+id/height"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="–" />
+                        android:text="@string/unknown" />
 
                     <TextView
                         style="@style/Details.Label"
-                        android:text="Height Over" />
+                        android:text="@string/Height_Over" />
 
                     <TextView
                         android:id="@+id/heightType"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="–" />
+                        android:text="@string/unknown" />
                 </TableRow>
 
                 <TableRow
@@ -432,23 +432,23 @@
 
                     <TextView
                         style="@style/Details.Label"
-                        android:text="Hori. Accuracy" />
+                        android:text="@string/Hori_Accuracy" />
 
                     <TextView
                         android:id="@+id/horizontalAccuracy"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="–" />
+                        android:text="@string/unknown" />
 
                     <TextView
                         style="@style/Details.Label"
-                        android:text="Vert. Acc." />
+                        android:text="@string/Vert_Acc" />
 
                     <TextView
                         android:id="@+id/verticalAccuracy"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="–" />
+                        android:text="@string/unknown" />
                 </TableRow>
 
                 <TableRow
@@ -457,23 +457,23 @@
 
                     <TextView
                         style="@style/Details.Label"
-                        android:text="Baro Acc." />
+                        android:text="@string/Baro_Acc" />
 
                     <TextView
                         android:id="@+id/baroAccuracy"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="–" />
+                        android:text="@string/unknown" />
 
                     <TextView
                         style="@style/Details.Label"
-                        android:text="Speed Acc." />
+                        android:text="@string/Speed_Acc" />
 
                     <TextView
                         android:id="@+id/speedAccuracy"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="–" />
+                        android:text="@string/unknown" />
                 </TableRow>
 
                 <TableRow
@@ -482,23 +482,23 @@
 
                     <TextView
                         style="@style/Details.Label"
-                        android:text="Time Acc." />
+                        android:text="@string/Time_Acc" />
 
                     <TextView
                         android:id="@+id/timeAccuracy"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="–" />
+                        android:text="@string/unknown" />
 
                     <TextView
                         style="@style/Details.Label"
-                        android:text="Timestamp" />
+                        android:text="@string/Timestamp" />
 
                     <TextView
                         android:id="@+id/timestamp"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="–" />
+                        android:text="@string/unknown" />
                 </TableRow>
 
             </TableLayout>
@@ -515,14 +515,14 @@
                 style="@style/Details.Heading"
                 android:layout_width="99dp"
                 android:layout_height="wrap_content"
-                android:text="Self ID" />
+                android:text="@string/Self_ID" />
 
             <TextView
                 android:id="@+id/selfIdLastUpdate"
                 android:layout_width="78dp"
                 android:layout_height="wrap_content"
                 android:layout_gravity="end"
-                android:text="–"
+                android:text="@string/unknown"
                 android:textAlignment="viewEnd" />
 
             <TableLayout
@@ -539,23 +539,23 @@
 
                     <TextView
                         style="@style/Details.Label"
-                        android:text="Operation" />
+                        android:text="@string/Operation" />
 
                     <TextView
                         android:id="@+id/selfIdDescription"
                         android:layout_width="162dp"
                         android:layout_height="wrap_content"
-                        android:text="–" />
+                        android:text="@string/unknown" />
 
                     <TextView
                         style="@style/Details.Label"
-                        android:text="Type" />
+                        android:text="@string/Type" />
 
                     <TextView
                         android:id="@+id/selfIdType"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="–" />
+                        android:text="@string/unknown" />
                 </TableRow>
 
             </TableLayout>
@@ -572,14 +572,14 @@
                 style="@style/Details.Heading"
                 android:layout_width="130dp"
                 android:layout_height="wrap_content"
-                android:text="System/Operator" />
+                android:text="@string/System_Operator" />
 
             <TextView
                 android:id="@+id/systemLastUpdate"
                 android:layout_width="78dp"
                 android:layout_height="wrap_content"
                 android:layout_gravity="end"
-                android:text="–"
+                android:text="@string/unknown"
                 android:textAlignment="viewEnd" />
 
             <TableLayout
@@ -596,23 +596,23 @@
 
                     <TextView
                         style="@style/Details.Label"
-                        android:text="Location Type" />
+                        android:text="@string/Location_Type" />
 
                     <TextView
                         android:id="@+id/operatorLocationType"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="–" />
+                        android:text="@string/unknown" />
 
                     <TextView
                         style="@style/Details.Label"
-                        android:text="Altitude" />
+                        android:text="@string/Altitude" />
 
                     <TextView
                         android:id="@+id/systemAltitudeGeo"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="–" />
+                        android:text="@string/unknown" />
                 </TableRow>
 
                 <TableRow
@@ -621,23 +621,23 @@
 
                     <TextView
                         style="@style/Details.Label"
-                        android:text="Latitude" />
+                        android:text="@string/Latitude" />
 
                     <TextView
                         android:id="@+id/systemLatitude"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="–" />
+                        android:text="@string/unknown" />
 
                     <TextView
                         style="@style/Details.Label"
-                        android:text="Longitude" />
+                        android:text="@string/Longitude" />
 
                     <TextView
                         android:id="@+id/systemLongitude"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="–" />
+                        android:text="@string/unknown" />
                 </TableRow>
 
                 <TableRow
@@ -646,23 +646,23 @@
 
                     <TextView
                         style="@style/Details.Label"
-                        android:text="Area Count" />
+                        android:text="@string/Area_Count" />
 
                     <TextView
                         android:id="@+id/systemAreaCount"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="–" />
+                        android:text="@string/unknown" />
 
                     <TextView
                         style="@style/Details.Label"
-                        android:text="Area Radius" />
+                        android:text="@string/Area_Radius" />
 
                     <TextView
                         android:id="@+id/systemAreaRadius"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="–" />
+                        android:text="@string/unknown" />
                 </TableRow>
 
                 <TableRow
@@ -671,23 +671,23 @@
 
                     <TextView
                         style="@style/Details.Label"
-                        android:text="Area Ceiling" />
+                        android:text="@string/Area_Ceiling" />
 
                     <TextView
                         android:id="@+id/systemAreaCeiling"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="–" />
+                        android:text="@string/unknown" />
 
                     <TextView
                         style="@style/Details.Label"
-                        android:text="Area Floor" />
+                        android:text="@string/Area_Floor" />
 
                     <TextView
                         android:id="@+id/systemAreaFloor"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="–" />
+                        android:text="@string/unknown" />
                 </TableRow>
 
                 <TableRow
@@ -696,23 +696,23 @@
 
                     <TextView
                         style="@style/Details.Label"
-                        android:text="Classification" />
+                        android:text="@string/Classification" />
 
                     <TextView
                         android:id="@+id/classificationType"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="–" />
+                        android:text="@string/unknown" />
 
                     <TextView
                         style="@style/Details.Label"
-                        android:text="Timestamp" />
+                        android:text="@string/Timestamp" />
 
                     <TextView
                         android:id="@+id/systemTimestamp"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="–" />
+                        android:text="@string/unknown" />
                 </TableRow>
 
                 <TableRow
@@ -721,23 +721,23 @@
 
                     <TextView
                         style="@style/Details.Label"
-                        android:text="Category" />
+                        android:text="@string/Category" />
 
                     <TextView
                         android:id="@+id/category"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="–" />
+                        android:text="@string/unknown" />
 
                     <TextView
                         style="@style/Details.Label"
-                        android:text="Class" />
+                        android:text="@string/Class" />
 
                     <TextView
                         android:id="@+id/classValue"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="–" />
+                        android:text="@string/unknown" />
                 </TableRow>
 
             </TableLayout>
@@ -754,14 +754,14 @@
                 style="@style/Details.Heading"
                 android:layout_width="99dp"
                 android:layout_height="wrap_content"
-                android:text="Operator ID" />
+                android:text="@string/Operator_ID" />
 
             <TextView
                 android:id="@+id/operatorIdLastUpdate"
                 android:layout_width="78dp"
                 android:layout_height="wrap_content"
                 android:layout_gravity="end"
-                android:text="–"
+                android:text="@string/unknown"
                 android:textAlignment="viewEnd" />
 
             <TableLayout
@@ -778,23 +778,23 @@
 
                     <TextView
                         style="@style/Details.Label"
-                        android:text="Operator ID" />
+                        android:text="@string/Operator_ID" />
 
                     <TextView
                         android:id="@+id/operatorId"
                         android:layout_width="162dp"
                         android:layout_height="wrap_content"
-                        android:text="–" />
+                        android:text="@string/unknown" />
 
                     <TextView
                         style="@style/Details.Label"
-                        android:text="Type" />
+                        android:text="@string/Type" />
 
                     <TextView
                         android:id="@+id/operatorIdType"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="–" />
+                        android:text="@string/unknown" />
                 </TableRow>
 
             </TableLayout>
@@ -811,14 +811,14 @@
                 style="@style/Details.Heading"
                 android:layout_width="99dp"
                 android:layout_height="wrap_content"
-                android:text="Authentication" />
+                android:text="@string/Authentication" />
 
             <TextView
                 android:id="@+id/authLastUpdate"
                 android:layout_width="78dp"
                 android:layout_height="wrap_content"
                 android:layout_gravity="end"
-                android:text="–"
+                android:text="@string/unknown"
                 android:textAlignment="viewEnd" />
 
             <TableLayout
@@ -835,23 +835,23 @@
 
                     <TextView
                         style="@style/Details.Label"
-                        android:text="Type" />
+                        android:text="@string/Type" />
 
                     <TextView
                         android:id="@+id/authType"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="–" />
+                        android:text="@string/unknown" />
 
                     <TextView
                         style="@style/Details.Label"
-                        android:text="Length" />
+                        android:text="@string/Length" />
 
                     <TextView
                         android:id="@+id/authLength"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="–" />
+                        android:text="@string/unknown" />
                 </TableRow>
 
                 <TableRow
@@ -860,14 +860,14 @@
 
                     <TextView
                         style="@style/Details.Label"
-                        android:text="Timestamp" />
+                        android:text="@string/Timestamp" />
 
                     <TextView
                         android:id="@+id/authTimestamp"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_span="3"
-                        android:text="–" />
+                        android:text="@string/unknown" />
                 </TableRow>
 
                 <TableRow
@@ -876,13 +876,13 @@
 
                     <TextView
                         style="@style/Details.Label"
-                        android:text="Authentication" />
+                        android:text="@string/Authentication" />
 
                     <TextView
                         android:id="@+id/authData"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="–"
+                        android:text="@string/unknown"
                         android:layout_span="3" />
                 </TableRow>
 

--- a/Android/app/src/main/res/menu/main_menu.xml
+++ b/Android/app/src/main/res/menu/main_menu.xml
@@ -9,20 +9,20 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
     <item
         android:id="@+id/clear"
-        android:title="Clear"
+        android:title="@string/Clear"
         app:showAsAction="ifRoom" />
     <item
         android:id="@+id/help"
-        android:title="Help"
+        android:title="@string/Help"
         app:showAsAction="ifRoom" />
     <item
         android:id="@+id/menu_log"
         android:checkable="true"
-        android:title="Log enabled"
+        android:title="@string/Log_enabled"
         app:showAsAction="never" />
     <item
         android:id="@+id/log_location"
-        android:title="Show log location"
+        android:title="@string/Show_log_location"
         app:showAsAction="never" />
     <item
         android:id="@+id/coded_phy"

--- a/Android/app/src/main/res/values-ja/strings.xml
+++ b/Android/app/src/main/res/values-ja/strings.xml
@@ -1,0 +1,89 @@
+<!--
+ Copyright (C) 2019 Intel Corporation
+
+ SPDX-License-Identifier: Apache-2.0
+
+ The Japanese language on which it is based is as follows
+   https://github.com/ToshihiroMakuuchi/receiver-android-jp
+
+!-->
+<resources>
+    <string name="app_name">OpenDroneID</string>
+    <string name="bt_not_supported">このデバイスはBluetoothに対応していません。</string>
+    <string name="bt_not_enabled_leaving">Bluetoothを有効にしないと、このアプリケーションは動作しません。</string>
+    <string name="wifi_not_enabled_leaving">WiFiを有効にしないと、このアプリケーションは動作しません。</string>
+    <string name="info">情報</string>
+
+    <string name="Clear">クリア</string>
+    <string name="Help">ヘルプ</string>
+    <string name="Log_enabled">Log有効</string>
+    <string name="Show_log_location">位置情報ログ閲覧</string>
+
+    <string name="coded_phy_not_supported">Coded Phy非対応</string>
+    <string name="coded_phy_supported">Coded Phy対応</string>
+    <string name="ea_not_supported">Extended Advertising非対応</string>
+    <string name="ea_supported">Extended Advertising対応</string>
+    <string name="nan_not_supported">WiFi NaN非対応</string>
+    <string name="nan_supported">WiFi NaN対応</string>
+
+    <string name="wifi_beacon_scan_not_supported">WiFi Beacon スキャン非対応</string>
+    <string name="wifi_beacon_scan_supported">WiFi Beacon スキャン対応</string>
+
+    <string name="permission_rationale_location">位置情報アクセスを有効にしないと、このアプリケーションは動作しません。</string>
+    <string name="permission_required_toast">このアプリケーションを動作させるためには、位置情報の許可が必要です。</string>
+
+    <string name="drone_icon_content_description">Droneアイコン</string>
+
+    <string name="bluetooth_help_heading">Bluetooth</string>
+    <string name="bluetooth_help_text">サンプル</string>
+    <string name="beacon_help_heading">Wi-Fi Beacon</string>
+    <string name="beacon_help_text">サンプル</string>
+    <string name="nan_help_heading">Wi-Fi NaN</string>
+    <string name="nan_help_text">サンプル</string>
+
+    <string name="Connection">接続情報</string>
+    <string name="unknown">–</string>
+    <string name="RSSI">RSSI</string>
+    <string name="MAC">MAC</string>
+    <string name="Started">開始</string>
+    <string name="Last_seen">最終更新</string>
+    <string name="Msg_8710">Msg &#8710;</string>
+    <string name="Distance">距離</string>
+    <string name="Basic_ID_1">登録記号 1</string>
+    <string name="Type">種類</string>
+    <string name="ID_Type">ID種別</string>
+    <string name="UAS_ID">無人機ID</string>
+    <string name="Basic_ID_2">登録記号 2</string>
+    <string name="Location">位置/方向/速度</string>
+    <string name="Latitude">緯度</string>
+    <string name="Longitude">経度</string>
+    <string name="Altitude_Press">気圧高度</string>
+    <string name="Alt_Geod">対地高度</string>
+    <string name="Direction">方向</string>
+    <string name="Status">ステータス</string>
+    <string name="Hori_Speed">速度</string>
+    <string name="Vert_Speed">垂直速度</string>
+    <string name="Height">高さ</string>
+    <string name="Height_Over">対地高度種別</string>
+    <string name="Hori_Accuracy">水平精度</string>
+    <string name="Vert_Acc">垂直精度</string>
+    <string name="Baro_Acc">気圧高度精度</string>
+    <string name="Speed_Acc">速度精度</string>
+    <string name="Time_Acc">時刻精度</string>
+    <string name="Timestamp">時刻</string>
+    <string name="Self_ID">セルフID情報</string>
+    <string name="Operation">運用情報</string>
+    <string name="System_Operator">システム/操縦者</string>
+    <string name="Location_Type">操縦者位置種別</string>
+    <string name="Altitude">操縦者高度</string>
+    <string name="Area_Count">エリアカウント</string>
+    <string name="Area_Radius">エリア半径</string>
+    <string name="Area_Ceiling">エリア上限</string>
+    <string name="Area_Floor">エリア下限</string>
+    <string name="Classification">エリア分類</string>
+    <string name="Category">カテゴリ</string>
+    <string name="Class">クラス</string>
+    <string name="Operator_ID">操縦者情報</string>
+    <string name="Authentication">認証情報</string>
+    <string name="Length">データ長</string>
+</resources>

--- a/Android/app/src/main/res/values/strings.xml
+++ b/Android/app/src/main/res/values/strings.xml
@@ -11,6 +11,11 @@
     <string name="wifi_not_enabled_leaving">This application will not work without enabling WiFi.</string>
     <string name="info">info</string>
 
+    <string name="Clear">Clear</string>
+    <string name="Help">Help</string>
+    <string name="Log_enabled">Log enabled</string>
+    <string name="Show_log_location">Show log location</string>
+
     <string name="coded_phy_not_supported">Coded Phy not supported</string>
     <string name="coded_phy_supported">Coded Phy supported</string>
     <string name="ea_not_supported">Extended Advertising not supported</string>
@@ -32,4 +37,50 @@
     <string name="beacon_help_text">Sample</string>
     <string name="nan_help_heading">Wi-Fi NaN</string>
     <string name="nan_help_text">Sample</string>
+
+    <string name="Connection">Connection</string>
+    <string name="unknown">–</string>
+    <string name="RSSI">RSSI</string>
+    <string name="MAC">MAC</string>
+    <string name="Started">Started</string>
+    <string name="Last_seen">Last seen</string>
+    <string name="Msg_8710">Msg &#8710;</string>
+    <string name="Distance">Distance</string>
+    <string name="Basic_ID_1">Basic ID 1</string>
+    <string name="Type">Type</string>
+    <string name="ID_Type">ID Type</string>
+    <string name="UAS_ID">UAS ID</string>
+    <string name="Basic_ID_2">Basic ID 2</string>
+    <string name="Location">Location</string>
+    <string name="Latitude">Latitude</string>
+    <string name="Longitude">Longitude</string>
+    <string name="Altitude_Press">Altitude Press.</string>
+    <string name="Alt_Geod">Alt. Geod.</string>
+    <string name="Direction">Direction</string>
+    <string name="Status">Status</string>
+    <string name="Hori_Speed">Hori. Speed</string>
+    <string name="Vert_Speed">Vert. Speed</string>
+    <string name="Height">Height</string>
+    <string name="Height_Over">Height Over</string>
+    <string name="Hori_Accuracy">Hori. Accuracy</string>
+    <string name="Vert_Acc">Vert. Acc.</string>
+    <string name="Baro_Acc">Baro Acc.</string>
+    <string name="Speed_Acc">Speed Acc.</string>
+    <string name="Time_Acc">Time Acc.</string>
+    <string name="Timestamp">Timestamp</string>
+    <string name="Self_ID">Self ID</string>
+    <string name="Operation">Operation</string>
+    <string name="System_Operator">System/Operator</string>
+    <string name="Location_Type">Location Type</string>
+    <string name="Altitude">Altitude</string>
+    <string name="Area_Count">Area Count</string>
+    <string name="Area_Radius">Area Radius</string>
+    <string name="Area_Ceiling">Area Ceiling</string>
+    <string name="Area_Floor">Area Floor</string>
+    <string name="Classification">Classification</string>
+    <string name="Category">Category</string>
+    <string name="Class">Class</string>
+    <string name="Operator_ID">Operator ID</string>
+    <string name="Authentication">Authentication</string>
+    <string name="Length">Length</string>
 </resources>


### PR DESCRIPTION
The remote ID for Japan is the F3411-19 specification.
This tool is useful in Japan.
I would like to support Japanese language.
I believe that supporting Japanese language will make it easier for many Japanese people to use this tool.

Japanese display

![IMG-8798](https://user-images.githubusercontent.com/646194/170302362-300661bb-02cc-4db2-b84d-ef7ee439e691.jpg)

![IMG-8799](https://user-images.githubusercontent.com/646194/170302422-972ec39a-44dc-48f2-9ff3-9cf658f727ff.jpg)

![IMG-8800](https://user-images.githubusercontent.com/646194/170302458-0113e8a8-88b9-4b44-bce8-94dd060b13b2.jpg)