### PR TITLE
transmitter devices: Unifly BLIP only supports BT4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 Android/.idea
 Android/keystore.properties
+.DS_Store

--- a/transmitter-devices.md
+++ b/transmitter-devices.md
@@ -43,7 +43,7 @@ The list is presented in alphabetical order.
 | DroneTag Mini | ✅   | ✅   | ❌           | ❌        | https://dronetag.cz/en/products/mini/               |
 | INVOLI LEMAN  | ❌   | ❌   |              | ✅        | https://www.involi.com/products/leman-drone-tracker |
 | Thales ScaleFlyt | ✅ | ✅  | ✅?         | ✅?       | https://www.scaleflyt.com/remoteid
-| Unifly BLIP   | ✅   | ?    | ❌           | ❌        | https://unifly.aero/products/blip                  |
+| Unifly BLIP   | ✅   | ❌    | ❌           | ❌        | https://unifly.aero/products/blip                  |
 
 ## Other Transmitter Implementations
 


### PR DESCRIPTION
The early versions of the BLIP that I have seen (as of a year ago or so) only supported BT4, so the BT5 column should have a "NO" until somebody confirms that BT5 has actually been added.
Unfortunately the website is not very concrete about the features, but it does not appear to have changed much since last year. Also it speaks about transmission distances of up to 200m, which is another hint at BT4-only support.