### PR TITLE
transmitter devices: update FLARM Atom

### DIFF
--- a/transmitter-devices.md
+++ b/transmitter-devices.md
@@ -41,9 +41,9 @@ The list is presented in alphabetical order.
 | ------------- | ---- | ---- | ------------ | --------- | --------------------------------------------------- | ------------ |
 | Aerobits idME | ✅   | ✅   | ❌           | ❌        | https://www.aerobits.pl/product/idme/               |              |
 | DroneBeacon   | ✅   | ✅   | ✅           | ✅        | https://dronescout.co/dronebeacon-remote-id-transponder/ |              |
-| Droniq Atom   | ?    | ?    | ?            | ✅        | https://droniq.de/en/products/atom-flarm           | (unverified) |
 | Dronetag Beacon | ✅ | ✅   | ❌           | ❌        | https://shop.dronetag.cz/en/products/21-dronetag-beacon.html |              |
 | Dronetag Mini | ✅   | ✅   | ❌           | ❌        | https://dronetag.cz/en/products/mini/               |              |
+| FLARM Atom UAV | ❌  | ❌   | ❌           | ❌        | https://flarm.com/products/uav/atom-uav-flarm-for-drones/ |              |
 | INVOLI LEMAN  | ❌   | ❌   | ?            | ✅        | https://www.involi.com/products/leman-drone-tracker | (unverified) |
 | Thales ScaleFlyt | ✅ | ✅  | ✅?          | ✅?       | https://www.scaleflyt.com/remoteid                   | (unverified) |
 | Unifly BLIP   | ✅   | ❌   | ❌           | ❌        | https://unifly.aero/products/blip                  |              |


### PR DESCRIPTION
Some notes on the device which is currently listed as "Droniq Atom":

* It's actually built by FLARM, Droniq is only selling it, so the name and link should probably be adjusted.
* I had the opportunity to test this device a couple of months ago. There was actually no trace of Remote ID support whatsoever, despite the FLARM website saying otherwise. We contacted the manufacturer, and all we got were promises for the future. Until those promises are fulfilled (and someone can confirm it), I think it's only fair that it is listed as "no support" instead of "unconfirmed" (if only to counteract the overzealous marketing promises on their website).