### PR TITLE
transmitter devices: update FLARM Atom

### DIFF
--- a/transmitter-devices.md
+++ b/transmitter-devices.md
@@ -44,7 +44,7 @@ The list is presented in alphabetical order.
 | Dronetag Beacon | ✅ | ✅   | ❌           | ❌        | https://shop.dronetag.cz/en/products/21-dronetag-beacon.html |              |
 | Dronetag Mini | ✅   | ✅   | ❌           | ❌        | https://dronetag.cz/en/products/mini/               |              |
 | EAMS Robotics | ?    | ✅?  | ?            | ?         | http://www.eams-robo.co.jp/remoteid.html            | (unverified) |
-| FLARM Atom UAV | ❌  | ❌   | ❌           | ❌        | https://flarm.com/products/uav/atom-uav-flarm-for-drones/ |              |
+| FLARM Atom UAV | ❌  | ❌   | ❌           | ✅        | https://flarm.com/products/uav/atom-uav-flarm-for-drones/ |              |
 | INVOLI LEMAN  | ❌   | ❌   | ?            | ✅        | https://www.involi.com/products/leman-drone-tracker | (unverified) |
 | Thales ScaleFlyt | ✅ | ✅  | ✅?          | ✅?       | https://www.scaleflyt.com/remoteid                   | (unverified) |
 | Unifly BLIP   | ✅   | ❌   | ❌           | ❌        | https://unifly.aero/products/blip                  |              |

--- a/transmitter-devices_jp.md
+++ b/transmitter-devices_jp.md
@@ -46,7 +46,7 @@
 | Dronetag Beacon | ✅ | ✅   | ❌           | ❌        | https://shop.dronetag.cz/en/products/21-dronetag-beacon.html |              |
 | Dronetag Mini | ✅   | ✅   | ❌           | ❌        | https://dronetag.cz/en/products/mini/               |              |
 | EAMS Robotics | ?    | ✅?  | ?            | ?         | http://www.eams-robo.co.jp/remoteid.html            | (unverified) |
-| FLARM Atom UAV | ❌  | ❌   | ❌           | ❌        | https://flarm.com/products/uav/atom-uav-flarm-for-drones/ |              |
+| FLARM Atom UAV | ❌  | ❌   | ❌           | ✅        | https://flarm.com/products/uav/atom-uav-flarm-for-drones/ |              |
 | INVOLI LEMAN  | ❌   | ❌   | ?            | ✅        | https://www.involi.com/products/leman-drone-tracker | (unverified) |
 | Thales ScaleFlyt | ✅ | ✅  | ✅?          | ✅?       | https://www.scaleflyt.com/remoteid                   | (unverified) |
 | Unifly BLIP   | ✅   | ❌   | ❌           | ❌        | https://unifly.aero/products/blip                  |              |


### PR DESCRIPTION
I had the chance to test an updated version of this device today, and I verified that it indeed supports DRI via WiFi NAN now (but neither Bluetooth nor WiFi Beacon).
