### PR TITLE
transmitter devices: verify DroneBeacon db120

### DIFF
--- a/transmitter-devices.md
+++ b/transmitter-devices.md
@@ -42,7 +42,7 @@ The list is presented in alphabetical order.
 | Aerobits idME | ✅   | ✅   | ❌           | ❌        | https://www.aerobits.pl/product/idme/               |              |
 | Aerobits idME Pro | ✅ | ✅ | ✅           | ✅        | https://www.aerobits.pl/product/idme-pro/           |              |
 | DroneBeacon db100  | ✅   | ✅   | ✅           | ✅        | https://dronescout.co/dronebeacon-remote-id-transponder/ |              |
-| DroneBeacon db120  | ✅   | ✅   | ✅           | ✅        | https://dronescout.co/dronebeacon-remote-id-transponder/ | (unverified) |
+| DroneBeacon db120  | ✅   | ✅   | ✅           | ✅        | https://dronescout.co/dronebeacon-remote-id-transponder/ |              |
 | Dronetag Beacon | ✅ | ✅   | ❌           | ❌        | https://shop.dronetag.cz/en/products/21-dronetag-beacon.html |              |
 | Dronetag Mini | ✅   | ✅   | ❌           | ❌        | https://dronetag.cz/en/products/mini/               |              |
 | EAMS Robotics | ?    | ✅?  | ?            | ?         | http://www.eams-robo.co.jp/remoteid.html            | (unverified) |

--- a/transmitter-devices_jp.md
+++ b/transmitter-devices_jp.md
@@ -43,7 +43,8 @@
 | ------------- | ---- | ---- | ------------ | --------- | --------------------------------------------------- | ------------ |
 | Aerobits idME | ✅   | ✅   | ❌           | ❌        | https://www.aerobits.pl/product/idme/               |              |
 | Aerobits idME Pro | ✅ | ✅ | ✅           | ✅        | https://www.aerobits.pl/product/idme-pro/           |              |
-| DroneBeacon   | ✅   | ✅   | ✅           | ✅        | https://dronescout.co/dronebeacon-remote-id-transponder/ |              |
+| DroneBeacon db100  | ✅   | ✅   | ✅           | ✅        | https://dronescout.co/dronebeacon-remote-id-transponder/ |              |
+| DroneBeacon db120  | ✅   | ✅   | ✅           | ✅        | https://dronescout.co/dronebeacon-remote-id-transponder/ |              |
 | Dronetag Beacon | ✅ | ✅   | ❌           | ❌        | https://shop.dronetag.cz/en/products/21-dronetag-beacon.html |              |
 | Dronetag Mini | ✅   | ✅   | ❌           | ❌        | https://dronetag.cz/en/products/mini/               |              |
 | EAMS Robotics | ?    | ✅?  | ?            | ?         | http://www.eams-robo.co.jp/remoteid.html            | (unverified) |


### PR DESCRIPTION
I can verify that the DroneBeacon db120 supports Remote ID via all four transmission methods.
(Also it was still missing in the Japanese version of the transmitter page.)
