### PR TITLE
Supported smartphones: add Samsung Galaxy Tab S8 etc

### DIFF
--- a/supported-smartphones.md
+++ b/supported-smartphones.md
@@ -267,5 +267,6 @@ We plan to continuously update this list and increase the reliability of informa
 | Huawei MediaPad M5                               | Kirin 960s        |  9 | ❌ 1/2021  | ❌ 1/2021   | ✅ 1/2020   | ❌ 1/2021  | [Link](receiver_proofs/Huawei_MediaPad_M5) | |
 | Nokia T10                                        |    | 12 | ✅ 1/2023  |            |           | ❌ | [Link](receiver_proofs/Nokia_T10) | The test unit didn't pick up any Long Range messages and, on investigation, showed a Bluetooth fault |
 | Samsung Tab A7 Lite                              |    | 12 | ✅ 1/2023  |            |           | ❌ | [Link](receiver_proofs/Samsung_Tab_A7_Lite) | Only seems to pick up a Long Range message every few seconds |
+| Samsung Galaxy Tab S8                            | Snapdragon 8 Gen 1 (SM8450) | 13 | ✅ 04/2023  | ✅ 04/2023 | ✅ 04/2023 | ✅ 04/2023 | | Receives Long Range continuously |
 | Samsung Galaxy Tab S7, S7+                       | Snapdragon 865+   |    |            |            |     ➕      | ✅ 1/2021  |      | |
 | Samsung Galaxy Tab S6                            | Snapdragon 855    |    | ✅ 6/2020   |            |     ➕      |            |      | |

--- a/supported-smartphones.md
+++ b/supported-smartphones.md
@@ -219,7 +219,7 @@ We plan to continuously update this list and increase the reliability of informa
 | Samsung Galaxy Note 8 (Global)                   | Exynos 8895       |  9 |            |            | ✅ 1/2020  |            |      | |
 | Samsung Galaxy Note 8 (USA, China, Japan)        | Snapdragon 835    |    |            |            |     ➕      |            |      | |
 | Samsung S22+                                     | Exynos 2200       | 12 | ✅ 03/2022 | ✅ 03/2022 | ✅ 03/2022 | ✅ 03/2022 | [Link](receiver_proofs/Samsung_Galaxy_S22+) | Receives Long Range continuously |
-| Samsung S21, S21+, S21 Ultra                     | Exynos 2100       | 11 | ✅ 11/2021 | ✅ 11/2021 | ✅ 11/2021 | ✅ 11/2021 |      | Receives Long Range continuously |
+| Samsung S21, S21+, S21 Ultra                     | Exynos 2100       | 11, 12, 13 | ✅ 11/2021 | ✅ 11/2021 | ✅ 11/2021 | ✅ 11/2021 |      | Receives Long Range continuously |
 | Samsung S20, S20+, S20 ultra (Global)            | Exynos 990        | 10 | ✅ 1/2021  | ✅ 1/2021  | ✅ 1/2020  | ✅ 1/2020  | [Link](receiver_proofs/Samsung_Galaxy_S20_Exynos) | |
 | Samsung S20, S20+, S20 ultra (USA, China, Japan) | Snapdragon 865    | 10 | ✅ 2/2021  | ✅ 2/2021  |      ➕     | ✅ 2/2021  |      | Receives Long Range continuously |
 | Samsung Galaxy S10, S10e, S10+, S10 5G           | Exynos 9820       | 10 | ✅ 1/2021  | ✅ 1/2021  | ✅ 1/2020  | ✅ 1/2020  | [Link](receiver_proofs/Samsung_Galaxy_S10_Exynos) | Receives Long Range continuously |

--- a/supported-smartphones.md
+++ b/supported-smartphones.md
@@ -160,6 +160,8 @@ Please note that most smartphones were tested in Q1 2020 and they do not contain
 Therefore, their functionality may have changed since.
 We plan to continuously update this list and increase the reliability of information by adding screenshot evidence.
 
+## Supported Smartphones
+
 | Smartphone Model | Chipset | Android version | BT 5 LR Basic Support (Elimination criteria) | BT 5 LR Receiver Support | Wi-Fi Beacon | Wi-Fi NAN  | Proof | Note |
 | ---------------- | ------- | --------------- | -------------------------------------------- | ------------------------ | ------------ | ---------- | ----- | ---- |
 | Asus Zenfone 6                                   | Snapdragon 855    | 11 | ✅ 1/2021  | ✅ 7/2021  | ✅ 7/2021  | ✅ 1/2021  | [Link](receiver_proofs/Asus_Zenfone6) | Does not receive Long Range continuously (gaps of up to 5 sec) |
@@ -190,7 +192,6 @@ We plan to continuously update this list and increase the reliability of informa
 | Huawei Honor View 10                             | Kirin 970         |  9 |            |            | ✅ 1/2020  |            |      | |
 | Huawei Honor 8S                                  | MT 6761 Helio A22 |  9 | ✅ 1/2020  |            |     ➕      | ❌ 1/2020  | [Link](receiver_proofs/Huawei_Honor_8S) | Not tested but expect the same behavior as the Nokia 2.2 |
 | Huawei Y6 Pro                                    | MT 6761 Helio A22 |  5 | ❌ 1/2020  | ❌ 1/2020   |            | ❌ 1/2020  |      | |
-| Huawei MediaPad M5                               | Kirin 960s        |  9 | ❌ 1/2021  | ❌ 1/2021   | ✅ 1/2020   | ❌ 1/2021  | [Link](receiver_proofs/Huawei_MediaPad_M5) | |
 | Huawei Nexus 6P                                  | Snapdragon 810    |  8 |            |            | ✅ 1/2020  |            | [Link](receiver_proofs/Huawei_Nexus_6P) | |
 | LG velvet 5G                                     | Snapdragon 765G   |    |            |            |     ➕     | ✅ 1/2021  |      | |
 | LG G8X                                           | Snapdragon 855    |    |            |            |     ➕     | ✅ 1/2021  |      | |
@@ -259,8 +260,11 @@ We plan to continuously update this list and increase the reliability of informa
 | Xiaomi Mi A2                                     | Snapdragon 660    |  9 | ❌ 1/2020  | ❌ 1/2020   |       ➕    | ❌ 1/2020  | [Link](receiver_proofs/Xiaomi_Mi_A2) | |
 
 
+## Supported Tablets
+
 | Tablet Model     | Chipset | Android version | BT 5 LR Basic Support (Elimination criteria) | BT 5 LR Receiver Support | Wi-Fi Beacon | Wi-Fi NAN  | Proof | Note |
 | ---------------- | ------- | --------------- | -------------------------------------------- | ------------------------ | ------------ | ---------- | ----- | ---- |
+| Huawei MediaPad M5                               | Kirin 960s        |  9 | ❌ 1/2021  | ❌ 1/2021   | ✅ 1/2020   | ❌ 1/2021  | [Link](receiver_proofs/Huawei_MediaPad_M5) | |
 | Nokia T10                                        |    | 12 | ✅ 1/2023  |            |           | ❌ | [Link](receiver_proofs/Nokia_T10) | The test unit didn't pick up any Long Range messages and, on investigation, showed a Bluetooth fault |
 | Samsung Tab A7 Lite                              |    | 12 | ✅ 1/2023  |            |           | ❌ | [Link](receiver_proofs/Samsung_Tab_A7_Lite) | Only seems to pick up a Long Range message every few seconds |
 | Samsung Galaxy Tab S7, S7+                       | Snapdragon 865+   |    |            |            |     ➕      | ✅ 1/2021  |      | |

--- a/supported-smartphones_jp.md
+++ b/supported-smartphones_jp.md
@@ -224,7 +224,7 @@ Wi-FiBeaconの結果についての特記事項となります。一部の端末
 | Samsung Galaxy Note 8 (Global)                   | Exynos 8895       |  9 |            |            | ✅ 1/2020  |            |      | |
 | Samsung Galaxy Note 8 (USA, China, Japan)        | Snapdragon 835    |    |            |            |     ➕      |            |      | |
 | Samsung S22+                                     | Exynos 2200       | 12 | ✅ 03/2022 | ✅ 03/2022 | ✅ 03/2022 | ✅ 03/2022 | [Link](receiver_proofs/Samsung_Galaxy_S22+) | Long Range通信を継続的に受信 |
-| Samsung S21, S21+, S21 Ultra                     | Exynos 2100       | 11 | ✅ 11/2021 | ✅ 11/2021 | ✅ 11/2021 | ✅ 11/2021 |      | Long Range通信を継続的に受信 |
+| Samsung S21, S21+, S21 Ultra                     | Exynos 2100       | 11, 12, 13 | ✅ 11/2021 | ✅ 11/2021 | ✅ 11/2021 | ✅ 11/2021 |      | Long Range通信を継続的に受信 |
 | Samsung S20, S20+, S20 ultra (Global)            | Exynos 990        | 10 | ✅ 1/2021  | ✅ 1/2021  | ✅ 1/2020  | ✅ 1/2020  | [Link](receiver_proofs/Samsung_Galaxy_S20_Exynos) | |
 | Samsung S20, S20+, S20 ultra (USA, China, Japan) | Snapdragon 865    | 10 | ✅ 2/2021  | ✅ 2/2021  |      ➕     | ✅ 2/2021  |      | Long Range通信を継続的に受信 |
 | Samsung Galaxy S10, S10e, S10+, S10 5G           | Exynos 9820       | 10 | ✅ 1/2021  | ✅ 1/2021  | ✅ 1/2020  | ✅ 1/2020  | [Link](receiver_proofs/Samsung_Galaxy_S10_Exynos) | Long Range通信を継続的に受信 |

--- a/supported-smartphones_jp.md
+++ b/supported-smartphones_jp.md
@@ -272,5 +272,6 @@ Wi-FiBeaconの結果についての特記事項となります。一部の端末
 | Huawei MediaPad M5                               | Kirin 960s        |  9 | ❌ 1/2021  | ❌ 1/2021   | ✅ 1/2020   | ❌ 1/2021  | [Link](receiver_proofs/Huawei_MediaPad_M5) | |
 | Nokia T10                                        |    | 12 | ✅ 1/2023  |            |           | ❌ | [Link](receiver_proofs/Nokia_T10) | The test unit didn't pick up any Long Range messages and, on investigation, showed a Bluetooth fault |
 | Samsung Tab A7 Lite                              |    | 12 | ✅ 1/2023  |            |           | ❌ | [Link](receiver_proofs/Samsung_Tab_A7_Lite) | Only seems to pick up a Long Range message every few seconds |
+| Samsung Galaxy Tab S8                            | Snapdragon 8 Gen 1 (SM8450) | 13 | ✅ 04/2023  | ✅ 04/2023 | ✅ 04/2023 | ✅ 04/2023 | | Long Range通信を継続的に受信 |
 | Samsung Galaxy Tab S7, S7+                       | Snapdragon 865+   |    |            |            |     ➕      | ✅ 1/2021  |      | |
 | Samsung Galaxy Tab S6                            | Snapdragon 855    |    | ✅ 6/2020   |            |     ➕      |            |      | |

--- a/supported-smartphones_jp.md
+++ b/supported-smartphones_jp.md
@@ -165,6 +165,8 @@ Wi-FiBeaconの結果についての特記事項となります。一部の端末
 そのため、その後機能が変更されている可能性があります。
 今後、一覧を継続的に更新し、スクリーンショットにて証跡追加することで情報の信頼性を高めていく予定です。
 
+## 対応スマートフォン
+
 | モデル名 | Chipset | Android Ver | BT5 LR 基本 | BT5 LR 受信 | Wi-Fi Beacon | Wi-Fi NAN  | 検証 | 備考 |
 | -------------------- | ------------ | ------------------------- | ------------------------------- | -------------------- | ------------ | ---------- | ---------- | ---- |
 | Asus Zenfone 6                                   | Snapdragon 855    | 11 | ✅ 1/2021  | ✅ 7/2021  | ✅ 7/2021  | ✅ 1/2021  | [Link](receiver_proofs/Asus_Zenfone6) | Long Rangeを連続受信できない (最大5秒間のギャップ) |
@@ -195,7 +197,6 @@ Wi-FiBeaconの結果についての特記事項となります。一部の端末
 | Huawei Honor View 10                             | Kirin 970         |  9 |            |            | ✅ 1/2020  |            |      | |
 | Huawei Honor 8S                                  | MT 6761 Helio A22 |  9 | ✅ 1/2020  |            |     ➕      | ❌ 1/2020  | [Link](receiver_proofs/Huawei_Honor_8S) | 未検証となるが、Nokia 2.2と同一な動作が期待できる |
 | Huawei Y6 Pro                                    | MT 6761 Helio A22 |  5 | ❌ 1/2020  | ❌ 1/2020   |            | ❌ 1/2020  |      | |
-| Huawei MediaPad M5                               | Kirin 960s        |  9 | ❌ 1/2021  | ❌ 1/2021   | ✅ 1/2020   | ❌ 1/2021  | [Link](receiver_proofs/Huawei_MediaPad_M5) | |
 | Huawei Nexus 6P                                  | Snapdragon 810    |  8 |            |            | ✅ 1/2020  |            | [Link](receiver_proofs/Huawei_Nexus_6P) | |
 | LG velvet 5G                                     | Snapdragon 765G   |    |            |            |     ➕     | ✅ 1/2021  |      | |
 | LG G8X                                           | Snapdragon 855    |    |            |            |     ➕     | ✅ 1/2021  |      | |
@@ -239,8 +240,6 @@ Wi-FiBeaconの結果についての特記事項となります。一部の端末
 | Samsung Galaxy M12                               | Exynos 850        | 11 | ✅ 03/2022 | ❌ 03/2022 | ✅ 03/2022  | ❌ 03/2022 | [Link](receiver_proofs/Samsung_Galaxy_m12) | |
 | Samsung Galaxy A52s                              | Snapdragon 778G   | 11 | ✅ 03/2022 | ✅ 03/2022 | ✅ 03/2022  | ✅ 03/2022 | [Link](receiver_proofs/Samsung_Galaxy_A52s)| |
 | Samsung Galaxy Xcover Pro                        | Snapdragon 865    | 10 |            |            |     ➕      | ✅ 1/2020  |      | |
-| Samsung Galaxy Tab S7, S7+                       | Snapdragon 865+   |    |            |            |     ➕      | ✅ 1/2021  |      | |
-| Samsung Galaxy Tab S6                            | Snapdragon 855    |    | ✅ 6/2020   |            |     ➕      |            |      | |
 | Samsung Galaxy A3                                | Exynos 7870       |    | ❌ 1/2021   | ❌ 1/2021   |     ➕      | ❌ 1/2021  |      | |
 | Sony XQ-AD52 Xperia L4                           | MT6762 Helio P22  |    | ✅ 1/2021   | ❌ 1/2021   |     ➕      | ❌ 1/2020  |      | |
 | Sony Xperia 10 III                               | Snapdragon 690    | 11 | ❌ 3/2022   |            | ✅ 3/2022  |              | [Link](receiver_proofs/Sony_Xperia_10_III) | |
@@ -264,3 +263,14 @@ Wi-FiBeaconの結果についての特記事項となります。一部の端末
 | Xiaomi Redmi K20 Pro                             | Snapdragon 855    |  9 |            |            |     ➕      | ✅ 1/2020  |      | |
 | Xiaomi Mi Mix 3                                  | Snapdragon 845    |  9 |            |            | ✅ 1/2020  | ✅ 1/2020  |      | |
 | Xiaomi Mi A2                                     | Snapdragon 660    |  9 | ❌ 1/2020  | ❌ 1/2020   |       ➕    | ❌ 1/2020  | [Link](receiver_proofs/Xiaomi_Mi_A2) | |
+
+
+## 対応タブレット
+
+| モデル名 | Chipset | Android Ver | BT5 LR 基本 | BT5 LR 受信 | Wi-Fi Beacon | Wi-Fi NAN  | 検証 | 備考 |
+| -------------------- | ------------ | ------------------------- | ------------------------------- | -------------------- | ------------ | ---------- | ---------- | ---- |
+| Huawei MediaPad M5                               | Kirin 960s        |  9 | ❌ 1/2021  | ❌ 1/2021   | ✅ 1/2020   | ❌ 1/2021  | [Link](receiver_proofs/Huawei_MediaPad_M5) | |
+| Nokia T10                                        |    | 12 | ✅ 1/2023  |            |           | ❌ | [Link](receiver_proofs/Nokia_T10) | The test unit didn't pick up any Long Range messages and, on investigation, showed a Bluetooth fault |
+| Samsung Tab A7 Lite                              |    | 12 | ✅ 1/2023  |            |           | ❌ | [Link](receiver_proofs/Samsung_Tab_A7_Lite) | Only seems to pick up a Long Range message every few seconds |
+| Samsung Galaxy Tab S7, S7+                       | Snapdragon 865+   |    |            |            |     ➕      | ✅ 1/2021  |      | |
+| Samsung Galaxy Tab S6                            | Snapdragon 855    |    | ✅ 6/2020   |            |     ➕      |            |      | |


### PR DESCRIPTION
This PR updates the list of supported smartphones (and tablets).

Its main purpose is to add the Samsung Galaxy Tab S8:
* I verified that this device supports all transmission methods (using universally transmitting devices like the BlueMark DroneBeacon and Aerobits idME Pro).
* It is hardly surprising that it supports everything, since other Samsung S-series flagship phones like the S21+ do this as well.
* I found no larger gaps in the BLE 5 long-range reception (nor in the WiFI-NAN reception).
* WiFi Beacon is supported as well, but the observed reception interval (around 4s) is somewhat larger than e.g. on the S21+ (roughly 2.5s, both with Android 13).

Furthermore the PR includes some minor updates & cleanup:
* I'm adding subsection headings in front of the table for smartphones and for tables (this makes it possible to link to those sections etc).
* I'm moving a tablet to the correct table (Huawei mediapad).
* I'm updating the Japanese version, so that it's compatible with the English version again.
* I'm updating the entry for the S21+, which seems to behave more-or-less the same way with all recent Android versions (11-13). At some point I thought I'd seen some BLE5 gaps with Android 13 (possibly related to power saving etc), but I could never reliably reproduce how often or under which circumstances they occur ...