### PR TITLE
Supported Smartphones: add Samsung A71 with Android 13

### DIFF
--- a/supported-smartphones.md
+++ b/supported-smartphones.md
@@ -228,6 +228,7 @@ We plan to continuously update this list and increase the reliability of informa
 | Samsung Galaxy S7                                | Exynos 8890       |    |            |            | ✅ 4/2021  |            | [Link]( receiver_proofs/Samsung_Galaxy_S7) | |
 | Samsung Galaxy S6                                | Exynos 7420       |    |            |            | ✅ 4/2021  |            | [Link](receiver_proofs/Samsung_Galaxy_S6) | |
 | Samsung Galaxy A5                                | Snapdragon 410    |    |            |            | ✅ 1/2020  |            |      | |
+| Samsung Galaxy A71                               | Snapdragon 730    | 13 | ✅ 4/2023  | ✅ 4/2023   | ✅ 4/2023  | ✅ 4/2023  | | Does not receive Long Range continuously (receiving for 4 sec, then 4 sec gap) |
 | Samsung Galaxy A71                               | Snapdragon 730    | 10 | ❌ 1/2021  | ❌ 1/2021   | ✅ 9/2021  | ✅ 1/2021  | [Link](receiver_proofs/Samsung_Galaxy_A71) | |
 | Samsung Galaxy A8                                | Exynos 7885       |    |            |            | ✅ 4/2021  |            | [Link](receiver_proofs/Samsung_Galaxy_A8) | |
 | Samsung Galaxy Xcover Pro                        | Exynos 9611       | 10 | ❌ 1/2020  | ❌ 1/2020   |      ➕     | ❌ 1/2020  | [Link](receiver_proofs/Samsung_Galaxy_XCover_Pro) | |

--- a/supported-smartphones_jp.md
+++ b/supported-smartphones_jp.md
@@ -233,6 +233,7 @@ Wi-FiBeaconの結果についての特記事項となります。一部の端末
 | Samsung Galaxy S7                                | Exynos 8890       |    |            |            | ✅ 4/2021  |            | [Link](receiver_proofs/Samsung_Galaxy_S7) | |
 | Samsung Galaxy S6                                | Exynos 7420       |    |            |            | ✅ 4/2021  |            | [Link](receiver_proofs/Samsung_Galaxy_S6) | |
 | Samsung Galaxy A5                                | Snapdragon 410    |    |            |            | ✅ 1/2020  |            |      | |
+| Samsung Galaxy A71                               | Snapdragon 730    | 13 | ✅ 4/2023  | ✅ 4/2023   | ✅ 4/2023  | ✅ 4/2023  | | |
 | Samsung Galaxy A71                               | Snapdragon 730    | 10 | ❌ 1/2021  | ❌ 1/2021   | ✅ 9/2021  | ✅ 1/2021  | [Link](receiver_proofs/Samsung_Galaxy_A71) | |
 | Samsung Galaxy A8                                | Exynos 7885       |    |            |            | ✅ 4/2021  |            | [Link](receiver_proofs/Samsung_Galaxy_A8) | |
 | Samsung Galaxy Xcover Pro                        | Exynos 9611       | 10 | ❌ 1/2020  | ❌ 1/2020   |      ➕     | ❌ 1/2020  | [Link](receiver_proofs/Samsung_Galaxy_XCover_Pro) | |

--- a/supported-smartphones_jp.md
+++ b/supported-smartphones_jp.md
@@ -233,7 +233,7 @@ Wi-FiBeaconの結果についての特記事項となります。一部の端末
 | Samsung Galaxy S7                                | Exynos 8890       |    |            |            | ✅ 4/2021  |            | [Link](receiver_proofs/Samsung_Galaxy_S7) | |
 | Samsung Galaxy S6                                | Exynos 7420       |    |            |            | ✅ 4/2021  |            | [Link](receiver_proofs/Samsung_Galaxy_S6) | |
 | Samsung Galaxy A5                                | Snapdragon 410    |    |            |            | ✅ 1/2020  |            |      | |
-| Samsung Galaxy A71                               | Snapdragon 730    | 13 | ✅ 4/2023  | ✅ 4/2023   | ✅ 4/2023  | ✅ 4/2023  | | |
+| Samsung Galaxy A71                               | Snapdragon 730    | 13 | ✅ 4/2023  | ✅ 4/2023   | ✅ 4/2023  | ✅ 4/2023  | | Does not receive Long Range continuously (receiving for 4 sec, then 4 sec gap) |
 | Samsung Galaxy A71                               | Snapdragon 730    | 10 | ❌ 1/2021  | ❌ 1/2021   | ✅ 9/2021  | ✅ 1/2021  | [Link](receiver_proofs/Samsung_Galaxy_A71) | |
 | Samsung Galaxy A8                                | Exynos 7885       |    |            |            | ✅ 4/2021  |            | [Link](receiver_proofs/Samsung_Galaxy_A8) | |
 | Samsung Galaxy Xcover Pro                        | Exynos 9611       | 10 | ❌ 1/2020  | ❌ 1/2020   |      ➕     | ❌ 1/2020  | [Link](receiver_proofs/Samsung_Galaxy_XCover_Pro) | |


### PR DESCRIPTION
This device seems to support BT5 now with the latest Android version. However, the BT5 reception does not work continuously. I see BT5 messages for 4 seconds, then a gap of 4 seconds and then messages again (repeating over and over).

Unfortunately I could not check the BT5 elimination criteria with nRF Connect (v4.26.1), since the app is crashing when I try to open the "Device Information" page on this device (no idea why, it seems to work well on other Android 13 devices). However, ODID (v3.4.3) shows "Coded PHY supported" and "Extended Advertising supported" and does receive BT5 messages. (Btw, maybe the testing methodology should be simplified a bit? AFAICS all the capabilities can be checked directly via the ODID app now, instead of nRF Connect and AIDA?)

One final question: Should we have multiple entries for a single device with different Android versions, like I did? (Note that for the S21+ I put three different Android versions in the same entry, since they all behave the same.) Or should we rather remove "outdated" OS versions (assuming that everyone will update to the latest available OS version anyway)?
