### PR TITLE
Fix permission flow to dynamically request BLUETOOTH_SCAN after NEARBY_WIFI_DEVICES is granted

### DIFF
--- a/Android/app/src/main/java/org/opendroneid/android/app/DebugActivity.java
+++ b/Android/app/src/main/java/org/opendroneid/android/app/DebugActivity.java
@@ -474,6 +474,16 @@ public class DebugActivity extends AppCompatActivity {
                     forceStopApp();
                     return;
                 }
+                else
+                {
+                    if (ActivityCompat.checkSelfPermission(this, Manifest.permission.BLUETOOTH_SCAN) == PackageManager.PERMISSION_GRANTED) {
+                        finalizeOnCreate();
+                    } else {
+                        Log.d(TAG, "onRequestPermissionsResult: Requesting BLUETOOTH_SCAN");
+                        ActivityCompat.requestPermissions(this, new String[] { Manifest.permission.BLUETOOTH_SCAN }, Constants.REQUEST_BLUETOOTH_PERMISSION_SCAN);
+                        return;
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
- Added a check in onRequestPermissionsResult to request BLUETOOTH_SCAN dynamically after NEARBY_WIFI_DEVICES permission is granted. 
- Prevents the need to close and reopen the app for Bluetooth permissions to be requested (happens only when the app is freshly installed and no cache, storage, and permissions have been used). 
- Improves user experience by making the permission flow seamless and automatic.